### PR TITLE
Increasing the flexibility of the code a bit more

### DIFF
--- a/src/main/java/com/edmartt/Main.java
+++ b/src/main/java/com/edmartt/Main.java
@@ -3,12 +3,13 @@ package com.edmartt;
 import com.edmartt.repository.IDao;
 import com.edmartt.repository.user_querys.UserQuerys;
 import com.edmartt.users.Users;
+import com.edmartt.repository.connector.Mariadb;
 
 public class Main {
 
     public static void main(String... args){
         Users user = new Users("Test", "Data", "Git", "mail@mail.com");
-        IDao querys = new UserQuerys();
+        IDao querys = new UserQuerys(new Mariadb());
         querys.add(user);
     }
 }

--- a/src/main/java/com/edmartt/repository/connector/IConnector.java
+++ b/src/main/java/com/edmartt/repository/connector/IConnector.java
@@ -1,0 +1,7 @@
+package com.edmartt.repository.connector;
+import java.sql.Connection;
+
+public interface IConnector {
+    public Connection getConnection();
+    public void closeConnection();
+}

--- a/src/main/java/com/edmartt/repository/connector/Mariadb.java
+++ b/src/main/java/com/edmartt/repository/connector/Mariadb.java
@@ -5,7 +5,7 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 
-public class Mariadb{
+public class Mariadb implements IConnector {
 
     private Connection connection=null;
     private final String DRIVER = "org.mariadb.jdbc.Driver";
@@ -13,6 +13,7 @@ public class Mariadb{
     private String PASSWORD = "";
     private final String DB_URL = "";
 
+    @Override
     public Connection getConnection() {
         try {
             Class.forName(DRIVER);
@@ -26,6 +27,7 @@ public class Mariadb{
         return connection;
     }
 
+    @Override
     public void closeConnection(){
         try {
             connection.close();

--- a/src/main/java/com/edmartt/repository/user_querys/UserQuerys.java
+++ b/src/main/java/com/edmartt/repository/user_querys/UserQuerys.java
@@ -11,17 +11,19 @@ import com.edmartt.repository.connector.Mariadb;
 public class UserQuerys implements IDao{
 
     private PreparedStatement preparedStm = null;
-    private Connection connection = null;
     private ResultSet result = null;
-    private Mariadb db_connector = null;
-
+	private IConnector connector;
+	
+	public UserQuerys(IConnector connector)
+	{
+		this.connector = connector;
+	}
+	
     @Override
     public void add(Users user){
-        db_connector = new Mariadb();
         String query = "INSERT INTO users (name, lastname, country, email) VALUES(?, ?, ?, ?)";
-        connection = db_connector.getConnection()  ;
-
-        try {
+        try(var connection = connector.getConnection())
+		{
             preparedStm = connection.prepareStatement(query);
             preparedStm.setString(1, user.getName());
             preparedStm.setString(2, user.getLastname());
@@ -34,18 +36,13 @@ public class UserQuerys implements IDao{
             }
         } catch (SQLException e) {
             System.out.println(e);
-        } finally{
-            db_connector.closeConnection();
         }
     }
 
     @Override
     public String get(String name){
-        db_connector = new Mariadb();
         String query="SELECT * FROM users WHERE name=?";
-        connection = db_connector.getConnection();
-        
-        try {
+        try(var connection = connector.getConnection()) {
             preparedStm = connection.prepareStatement(query);
             preparedStm.setString(1, name);
             this.result = preparedStm.executeQuery();
@@ -55,9 +52,6 @@ public class UserQuerys implements IDao{
         }
         catch (SQLException e) {   
             System.out.println(e);
-        }
-        finally{
-            db_connector.closeConnection();
         }
         return "The user doesn't exists";
     }

--- a/src/main/java/com/edmartt/repository/user_querys/UserQuerys.java
+++ b/src/main/java/com/edmartt/repository/user_querys/UserQuerys.java
@@ -9,9 +9,6 @@ import com.edmartt.repository.IDao;
 import com.edmartt.repository.connector.Mariadb;
 
 public class UserQuerys implements IDao{
-
-    private PreparedStatement preparedStm = null;
-    private ResultSet result = null;
 	private IConnector connector;
 	
 	public UserQuerys(IConnector connector)
@@ -24,7 +21,7 @@ public class UserQuerys implements IDao{
         String query = "INSERT INTO users (name, lastname, country, email) VALUES(?, ?, ?, ?)";
         try(var connection = connector.getConnection())
 		{
-            preparedStm = connection.prepareStatement(query);
+            var preparedStm = connection.prepareStatement(query);
             preparedStm.setString(1, user.getName());
             preparedStm.setString(2, user.getLastname());
             preparedStm.setString(3, user.getCountry());
@@ -43,10 +40,10 @@ public class UserQuerys implements IDao{
     public String get(String name){
         String query="SELECT * FROM users WHERE name=?";
         try(var connection = connector.getConnection()) {
-            preparedStm = connection.prepareStatement(query);
+            var preparedStm = connection.prepareStatement(query);
             preparedStm.setString(1, name);
-            this.result = preparedStm.executeQuery();
-            if(this.result.next()){
+            var result = preparedStm.executeQuery();
+            if(result.next()){
                 return result.getString("name");
             }
         }

--- a/src/main/java/com/edmartt/repository/user_querys/UserQuerys.java
+++ b/src/main/java/com/edmartt/repository/user_querys/UserQuerys.java
@@ -6,7 +6,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Connection;
 import com.edmartt.repository.IDao;
-import com.edmartt.repository.connector.Mariadb;
+import com.edmartt.repository.connector.IConnector;
 
 public class UserQuerys implements IDao{
 	private IConnector connector;


### PR DESCRIPTION
**Some changes I have made:**

- `UserQuerys` class should not create the instance of the connector (MariaDb) directly, otherwise, the class will only work with one connector. For that reason, I used an interface to not depend on the implementation and also injected the dependency in the constructor, so the class can use any connector that implements the `IConnector` interface.

- The `try-with-resources` feature of Java is used so that I don't have to release the resources manually.

- In the `UserQuerys` class there were two attributes declared:
```java
  private PreparedStatement preparedStm = null;
  private ResultSet result = null;
```
I have removed those two attributes, normally you have to try to limit the scope of variables.